### PR TITLE
npm update

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
     "url": "https://github.com/github/hubot.git"
   },
   "dependencies": {
-    "cheerio": "^0.19.0",
+    "cheerio": "^0.20.0",
     "hipchatter": "^0.2.0",
-    "hubot": "^2.17.0",
-    "hubot-hipchat": "^2.12.0",
+    "hubot": "^2.18.0",
+    "hubot-hipchat": "^2.12.0-6",
     "hubot-scripts": "^2.16.2",
-    "hubot-standup-alarm": "github:hubot-scripts/hubot-standup-alarm#083240dca1474f65de11fadb8aa67c15d4e33cc6",
+    "hubot-standup-alarm": "0.0.7",
     "ntwitter": "https://github.com/sebhildebrandt/ntwitter/tarball/master"
   },
   "engines": {
-    "node": ">= 0.8.x",
-    "npm": ">= 1.1.x"
+    "node": "4.4.x",
+    "npm": ">= 2.14.x"
   }
 }


### PR DESCRIPTION
* Newer hubot should work with node 4.x according to their Travis tests
* hubot-standup-alarm hopefully works better for us